### PR TITLE
feat: rename project from ebook-converter to aphrael

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# ebook-converter CLAUDE.md
+# aphrael CLAUDE.md
 
 ## 必須チェック項目
 
@@ -10,5 +10,5 @@
 
 ## プロジェクト概要
 
-calibre の `ebook-convert` ツールを EPUB/MOBI/AZW3 のみ対応のスタンドアロン Python パッケージとして再構成。
+calibre の `ebook-convert` ツールを基に EPUB/MOBI/AZW3 のみ対応のスタンドアロン Python パッケージとして再構成。
 C 拡張を純粋 Python で置き換え、不要モジュール（GUI, AI, デバイス等）を除去。

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,93 @@
+# aphrael
+
+[calibre](https://calibre-ebook.com/) の電子書籍変換エンジンを EPUB / MOBI / AZW3 に特化して抽出したスタンドアロン Python パッケージです。
+GUI やデバイス連携などの不要モジュールを除去し、C 拡張を純粋 Python で置き換えることで、軽量かつ CLI だけで変換が完結します。
+
+[English](README.md)
+
+## 対応フォーマット
+
+| 方向 | フォーマット |
+|------|-------------|
+| 入力 | EPUB, MOBI, AZW3, AZW, PRC, KEPUB |
+| 出力 | EPUB, MOBI, AZW3, OEB |
+
+## 要件
+
+- Python 3.10 以上
+- [uv](https://docs.astral.sh/uv/) (推奨)
+
+## インストール
+
+`uv tool install` を使ってシステムワイドにコマンドを導入するのが最も簡単です。
+
+```bash
+uv tool install git+https://github.com/yuanying/aphrael.git
+```
+
+インストール後は `aphrael` コマンドがそのまま使えます。
+
+```bash
+aphrael --version
+```
+
+## 使い方
+
+基本構文:
+
+```bash
+aphrael <入力ファイル> <出力ファイル> [オプション]
+```
+
+出力フォーマットは出力ファイルの拡張子から自動判定されます。
+
+### 変換例
+
+```bash
+# EPUB → MOBI
+aphrael book.epub book.mobi
+
+# EPUB → AZW3
+aphrael book.epub book.azw3
+
+# AZW3 → EPUB
+aphrael book.azw3 book.epub
+
+# 入力ファイル名をそのまま使い、拡張子だけ指定
+aphrael book.epub .mobi
+```
+
+### オプションの確認
+
+入力・出力フォーマットによって利用可能なオプションが変わります。具体的なオプションを確認するには:
+
+```bash
+aphrael input.epub output.mobi -h
+```
+
+変換システムの詳細なドキュメントは calibre のマニュアルを参照してください:
+https://manual.calibre-ebook.com/conversion.html
+
+## 開発
+
+```bash
+git clone https://github.com/yuanying/aphrael.git
+cd aphrael
+uv sync
+```
+
+### テスト
+
+```bash
+uv run pytest tests/
+```
+
+### リント
+
+```bash
+uv run ruff check src/
+```
+
+## ライセンス
+
+GPL-3.0-only (calibre と同一)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,93 @@
-# ebook-converter
+# aphrael
 
-Standalone ebook converter for EPUB/MOBI/AZW3, extracted from calibre.
+A standalone Python package that extracts [calibre](https://calibre-ebook.com/)'s ebook conversion engine, focused on EPUB / MOBI / AZW3 formats.
+Unnecessary modules (GUI, device integration, etc.) have been removed and C extensions replaced with pure Python, resulting in a lightweight CLI-only converter.
+
+[日本語](README.ja.md)
+
+## Supported Formats
+
+| Direction | Formats |
+|-----------|---------|
+| Input     | EPUB, MOBI, AZW3, AZW, PRC, KEPUB |
+| Output    | EPUB, MOBI, AZW3, OEB |
+
+## Requirements
+
+- Python 3.10+
+- [uv](https://docs.astral.sh/uv/) (recommended)
+
+## Installation
+
+The easiest way is to install via `uv tool install`:
+
+```bash
+uv tool install git+https://github.com/yuanying/aphrael.git
+```
+
+After installation, the `aphrael` command is available directly:
+
+```bash
+aphrael --version
+```
+
+## Usage
+
+Basic syntax:
+
+```bash
+aphrael <input_file> <output_file> [options]
+```
+
+The output format is automatically determined from the file extension of the output file.
+
+### Examples
+
+```bash
+# EPUB to MOBI
+aphrael book.epub book.mobi
+
+# EPUB to AZW3
+aphrael book.epub book.azw3
+
+# AZW3 to EPUB
+aphrael book.azw3 book.epub
+
+# Derive output filename from input, specifying only the extension
+aphrael book.epub .mobi
+```
+
+### Checking Available Options
+
+Available options vary depending on the input and output formats. To see format-specific options:
+
+```bash
+aphrael input.epub output.mobi -h
+```
+
+For detailed documentation on the conversion system, refer to the calibre manual:
+https://manual.calibre-ebook.com/conversion.html
+
+## Development
+
+```bash
+git clone https://github.com/yuanying/aphrael.git
+cd aphrael
+uv sync
+```
+
+### Testing
+
+```bash
+uv run pytest tests/
+```
+
+### Linting
+
+```bash
+uv run ruff check src/
+```
 
 ## License
 
-GPL-3.0 (same as calibre)
+GPL-3.0-only (same as calibre)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "ebook-converter"
+name = "aphrael"
 version = "0.1.0"
 description = "Standalone ebook converter for EPUB/MOBI/AZW3, extracted from calibre"
 readme = "README.md"
@@ -19,7 +19,7 @@ dependencies = [
 ]
 
 [project.scripts]
-ebook-convert = "calibre.ebooks.conversion.cli:main"
+aphrael = "calibre.ebooks.conversion.cli:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/calibre/customize/__init__.py
+++ b/src/calibre/customize/__init__.py
@@ -145,7 +145,7 @@ class Plugin:  # {{{
         True if the user clicks OK, False otherwise. The changes are
         automatically applied.
         '''
-        raise NotImplementedError('GUI not available in standalone ebook-converter')
+        raise NotImplementedError('GUI not available in standalone aphrael')
 
     def load_resources(self, names):
         '''

--- a/src/calibre/customize/builtins.py
+++ b/src/calibre/customize/builtins.py
@@ -2,7 +2,7 @@ __license__   = 'GPL v3'
 __copyright__ = '2008, Kovid Goyal <kovid at kovidgoyal.net>'
 
 '''
-Builtin plugins for ebook-converter.
+Builtin plugins for aphrael.
 Only EPUB/MOBI/AZW3 metadata and conversion plugins are registered.
 '''
 

--- a/src/calibre/customize/ui.py
+++ b/src/calibre/customize/ui.py
@@ -2,7 +2,7 @@ __license__   = 'GPL v3'
 __copyright__ = '2008, Kovid Goyal <kovid at kovidgoyal.net>'
 
 '''
-Simplified plugin UI for ebook-converter.
+Simplified plugin UI for aphrael.
 Only conversion-related functions are provided.
 '''
 

--- a/src/calibre/ebooks/conversion/cli.py
+++ b/src/calibre/ebooks/conversion/cli.py
@@ -286,7 +286,7 @@ def option_parser():
     parser = OptionParser(usage=USAGE)
     parser.add_option('--list-recipes', default=False, action='store_true',
             help=_('List builtin recipe names. You can create an e-book from '
-                'a builtin recipe like this: ebook-convert "Recipe Name.recipe" '
+                'a builtin recipe like this: aphrael "Recipe Name.recipe" '
                 'output.epub'))
     return parser
 
@@ -309,7 +309,7 @@ def create_option_parser(args, log):
         log('Created by:', __author__)
         raise SystemExit(0)
     if '--list-recipes' in args:
-        log('Recipes are not supported in ebook-converter')
+        log('Recipes are not supported in aphrael')
         raise SystemExit(0)
 
     parser = option_parser()

--- a/src/calibre/ebooks/mobi/writer8/index.py
+++ b/src/calibre/ebooks/mobi/writer8/index.py
@@ -385,8 +385,8 @@ if __name__ == '__main__':
     with open(src, 'wb') as f:
         f.write(raw.encode('utf-8'))
 
-    subprocess.check_call(['ebook-convert', src, '.epub', '--level1-toc', '//h:p', '--no-default-epub-cover', '--flow-size', '1000000'])
-    subprocess.check_call(['ebook-convert', src, '.azw3', '--level1-toc', '//h:p', '--no-inline-toc', '--extract-to=x'])
+    subprocess.check_call(['aphrael', src, '.epub', '--level1-toc', '//h:p', '--no-default-epub-cover', '--flow-size', '1000000'])
+    subprocess.check_call(['aphrael', src, '.azw3', '--level1-toc', '//h:p', '--no-inline-toc', '--extract-to=x'])
     subprocess.call(['kindlegen', 'index.epub'])  # kindlegen exit code is not 0 as we don't have a cover
     subprocess.check_call(['calibre-debug', 'index.mobi'])
 

--- a/src/calibre/ebooks/oeb/polish/tests/base.py
+++ b/src/calibre/ebooks/oeb/polish/tests/base.py
@@ -46,7 +46,7 @@ def needs_recompile(obj, srcs):
 
 def build_book(src, dest, args=()):
     from calibre.ebooks.conversion.cli import main
-    main(['ebook-convert', src, dest, '-vv'] + list(args))
+    main(['aphrael', src, dest, '-vv'] + list(args))
 
 
 def add_resources(raw, rmap):

--- a/tests/features/convert.feature
+++ b/tests/features/convert.feature
@@ -1,5 +1,5 @@
 Feature: Ebook format conversion
-  As a user of ebook-converter
+  As a user of aphrael
   I want to convert ebooks between EPUB, MOBI, and AZW3 formats
   So that I can read them on different devices
 
@@ -29,9 +29,9 @@ Feature: Ebook format conversion
     And the output file should be a valid "epub" file
 
   Scenario: Show help message
-    When I run ebook-convert with "--help"
+    When I run aphrael with "--help"
     Then it should display usage information
 
   Scenario: Show version
-    When I run ebook-convert with "--version"
+    When I run aphrael with "--version"
     Then it should display version information

--- a/tests/features/test_convert.py
+++ b/tests/features/test_convert.py
@@ -121,7 +121,7 @@ def when_convert_mobi_to_format(conversion_context, output_format):
     return {'returncode': result.returncode, 'stdout': result.stdout, 'stderr': result.stderr}
 
 
-@when(parsers.parse('I run ebook-convert with "{args}"'), target_fixture='cli_result')
+@when(parsers.parse('I run aphrael with "{args}"'), target_fixture='cli_result')
 def when_run_with_args(args):
     result = subprocess.run(
         [sys.executable, '-m', 'calibre.ebooks.conversion.cli'] + args.split(),

--- a/uv.lock
+++ b/uv.lock
@@ -3,47 +3,7 @@ revision = 3
 requires-python = ">=3.10"
 
 [[package]]
-name = "beautifulsoup4"
-version = "4.14.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "soupsieve" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
-]
-
-[[package]]
-name = "chardet"
-version = "5.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/0d/f7b6ab21ec75897ed80c17d79b15951a719226b9fababf1e40ea74d69079/chardet-5.2.0.tar.gz", hash = "sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7", size = 2069618, upload-time = "2023-08-01T19:23:02.662Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/6f/f5fbc992a329ee4e0f288c1fe0e2ad9485ed064cac731ed2fe47dcc38cbf/chardet-5.2.0-py3-none-any.whl", hash = "sha256:e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970", size = 199385, upload-time = "2023-08-01T19:23:00.661Z" },
-]
-
-[[package]]
-name = "colorama"
-version = "0.4.6"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
-]
-
-[[package]]
-name = "css-parser"
-version = "1.0.10"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2e/19/3191601557361c870bacd73ed9b266e0c198ca57a269608db81bcdc0394a/css-parser-1.0.10.tar.gz", hash = "sha256:bf1e972ad33344e93206964fb4cd908d9ddef9fcd0c01fa93e0d734675394363", size = 349673, upload-time = "2023-10-21T09:07:23.52Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/01/4a633580393fa23e17c22f5782886e898c0fdbdb9e77736552a7a12637b5/css_parser-1.0.10-py2.py3-none-any.whl", hash = "sha256:d2e955a114829f0a327cc5535c2e65fe2e40b883b892881017d419a3b6dd05b7", size = 197965, upload-time = "2023-10-21T09:07:21.119Z" },
-]
-
-[[package]]
-name = "ebook-converter"
+name = "aphrael"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
@@ -85,6 +45,46 @@ dev = [
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-bdd", specifier = ">=8.1.0" },
     { name = "ruff", specifier = ">=0.15.1" },
+]
+
+[[package]]
+name = "beautifulsoup4"
+version = "4.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
+]
+
+[[package]]
+name = "chardet"
+version = "5.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/0d/f7b6ab21ec75897ed80c17d79b15951a719226b9fababf1e40ea74d69079/chardet-5.2.0.tar.gz", hash = "sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7", size = 2069618, upload-time = "2023-08-01T19:23:02.662Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/6f/f5fbc992a329ee4e0f288c1fe0e2ad9485ed064cac731ed2fe47dcc38cbf/chardet-5.2.0-py3-none-any.whl", hash = "sha256:e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970", size = 199385, upload-time = "2023-08-01T19:23:00.661Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "css-parser"
+version = "1.0.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/19/3191601557361c870bacd73ed9b266e0c198ca57a269608db81bcdc0394a/css-parser-1.0.10.tar.gz", hash = "sha256:bf1e972ad33344e93206964fb4cd908d9ddef9fcd0c01fa93e0d734675394363", size = 349673, upload-time = "2023-10-21T09:07:23.52Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/01/4a633580393fa23e17c22f5782886e898c0fdbdb9e77736552a7a12637b5/css_parser-1.0.10-py2.py3-none-any.whl", hash = "sha256:d2e955a114829f0a327cc5535c2e65fe2e40b883b892881017d419a3b6dd05b7", size = 197965, upload-time = "2023-10-21T09:07:21.119Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Rename package from `ebook-converter` to `aphrael` across all files (pyproject.toml, source, tests, docs)
- Rename CLI entry point from `ebook-convert` to `aphrael`
- Add comprehensive README.md (English) and README.ja.md (Japanese)
- Regenerate uv.lock

## Changed files

- `pyproject.toml` — package name and script entry point
- `uv.lock` — regenerated
- `src/calibre/ebooks/conversion/cli.py` — user-facing messages
- `src/calibre/customize/__init__.py` — error message
- `src/calibre/customize/builtins.py` — docstring
- `src/calibre/customize/ui.py` — docstring
- `src/calibre/ebooks/oeb/polish/tests/base.py` — argv[0]
- `src/calibre/ebooks/mobi/writer8/index.py` — subprocess calls
- `tests/features/convert.feature` — step strings
- `tests/features/test_convert.py` — step decorator
- `README.md` — rewritten in English with full documentation
- `README.ja.md` — new Japanese translation
- `CLAUDE.md` — title and description

## Note

- `calibre` package name and import paths are intentionally unchanged (preserving calibre-derived code)

## Test plan

- [x] `uv run ruff check src/` — no new lint errors in changed files
- [x] `uv run pytest tests/` — all 38 tests passed