### PR TITLE
docs: add system library requirements for lxml/html5-parser

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -16,6 +16,25 @@ GUI やデバイス連携などの不要モジュールを除去し、C 拡張�
 
 - Python 3.10 以上
 - [uv](https://docs.astral.sh/uv/) (推奨)
+- システムライブラリ: `libxml2-dev`, `libxslt1-dev`（ビルド済みホイールが利用できない環境で `lxml` / `html5-parser` のビルドに必要）
+
+Debian/Ubuntu:
+
+```bash
+sudo apt install libxml2-dev libxslt1-dev
+```
+
+Fedora/RHEL:
+
+```bash
+sudo dnf install libxml2-devel libxslt-devel
+```
+
+macOS (Homebrew):
+
+```bash
+brew install libxml2 libxslt
+```
 
 ## インストール
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,25 @@ Unnecessary modules (GUI, device integration, etc.) have been removed and C exte
 
 - Python 3.10+
 - [uv](https://docs.astral.sh/uv/) (recommended)
+- System libraries: `libxml2-dev`, `libxslt1-dev` (required to build `lxml` and `html5-parser` when pre-built wheels are not available)
+
+On Debian/Ubuntu:
+
+```bash
+sudo apt install libxml2-dev libxslt1-dev
+```
+
+On Fedora/RHEL:
+
+```bash
+sudo dnf install libxml2-devel libxslt-devel
+```
+
+On macOS (Homebrew):
+
+```bash
+brew install libxml2 libxslt
+```
 
 ## Installation
 


### PR DESCRIPTION
## Summary

- `lxml` と `html5-parser` のビルドに必要なシステムライブラリ (`libxml2-dev`, `libxslt1-dev`) を README に追記
- Debian/Ubuntu, Fedora/RHEL, macOS (Homebrew) のインストールコマンドを記載

## Test plan

- [x] ドキュメントのみの変更のため、コードへの影響なし
- [x] `uv run ruff check src/` パス
- [x] `uv run pytest tests/` 全39テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)